### PR TITLE
only de/re activate tokens for changed partitions

### DIFF
--- a/lib/wongi/engine/beta/aggregate.ex
+++ b/lib/wongi/engine/beta/aggregate.ex
@@ -86,19 +86,19 @@ defmodule Wongi.Engine.Beta.Aggregate do
   end
 
   defp evaluate_changed_partition(node, token_partition, partition_f, betas, rete) do
-    groups =
+    group =
       if token_partition do
         Enum.group_by(Rete.tokens(rete, node), partition_f)
         |> Map.get(token_partition)
-        |> case do
-          nil -> []
-          partition -> [partition]
-        end
       else
-        [Rete.tokens(rete, node)]
+        Rete.tokens(rete, node)
       end
 
-    Enum.reduce(groups, rete, &evaluate_partition(node, betas, &1, &2))
+    if group do
+      evaluate_partition(node, betas, group, rete)
+    else
+      rete
+    end
   end
 
   defp evaluate_partition(node, betas, tokens, rete) do


### PR DESCRIPTION
I have a chain of 8 rules, 4 of which have aggregations in them

With a small test dataset of 8 maps (decomposed into Facts), I was seeing 564 activations of the final rule... and I thought the most optimal number of activations of the final rule should be much much smaller

My suspiction was that a big part of the large number of activations was the combinatorial explosion caused by the the chained aggregations and the "deactivate-everything then reactivate-everything" approach `Beta.Aggregate.evaluate` and `Beta.Aggregate.evaluate_partition` take

This PR:

* identifies which partition the activated/deactivated Token affects
* only deactivate/reactivate Tokens for that partition

On my test dataset all my tests still pass, and I'm now seeing only 4 activations of the final rule, which I think is ideal

What do you think of this approach ? Does it seem reasonable ? If something is off, I'm very happy to make any changes you want :) 