### PR TITLE
fix WME Inspect crash

### DIFF
--- a/lib/wongi/engine/wme.ex
+++ b/lib/wongi/engine/wme.ex
@@ -98,11 +98,11 @@ defmodule Wongi.Engine.WME do
     def inspect(%@for{subject: s, predicate: p, object: o}, opts) do
       concat([
         "WME.new(",
-        Inspect.inspect(s, opts),
+        to_doc(s, opts),
         ", ",
-        Inspect.inspect(p, opts),
+        to_doc(p, opts),
         ", ",
-        Inspect.inspect(o, opts),
+        to_doc(o, opts),
         ")"
       ])
     end

--- a/test/wongi/engine/wme_test.exs
+++ b/test/wongi/engine/wme_test.exs
@@ -51,4 +51,9 @@ defmodule Wongi.Engine.WMETest do
     assert {[:subject, :object], [:a, :c]} = index_pattern(new(:a, :_, :c))
     assert {[:predicate, :object], [:b, :c]} = index_pattern(new(:_, :b, :c))
   end
+
+  test "pretty inspect works with Vars" do
+    wme = new(%Wongi.Engine.DSL.Var{name: :x}, :p, 1)
+    assert inspect(wme, pretty: true) =~ "WME.new("
+  end
 end


### PR DESCRIPTION
this PR is against the current release, 0.9.18, and fixes an `inspect` crash from WMEs

the crash seems to be caught internally by `inspect`, so doesn't appear to affect program function - but it does make inspecting the Wongi structs impossible

```
%Wongi.Engine.DSL.Rule{
  ref: #Reference<0.880687438.2823028737.229486>,
  name: nil,
  forall: [
    %Wongi.Engine.DSL.Has{
      subject: %Wongi.Engine.DSL.Var{name: :planet},
      predicate: :satellite,
      object: %Wongi.Engine.DSL.Var{name: :satellite},
      filters: nil
    },
    %Wongi.Engine.DSL.Has{
      subject: %Wongi.Engine.DSL.Var{name: :satellite},
      predicate: :mass,
      object: %Wongi.Engine.DSL.Var{name: :sat_mass},
      filters: nil
    },
    %Wongi.Engine.DSL.Filter{
      filter: %Wongi.Engine.Filter.GTE{
        a: %Wongi.Engine.DSL.Var{name: :sat_mass},
        b: 10
      }
    },
    %Wongi.Engine.DSL.Aggregate{
      fun: &Enum.count/1,
      var: :count_heavy_sats,
      opts: [over: :sat_mass]
    }
  ],
  actions: [
    %Wongi.Engine.Action.Generator{
      template: #Inspect.Error<
  got FunctionClauseError with message:

      """
      no function clause matching in Inspect.Algebra.concat/2
      """

  while inspecting:

      %{
        __struct__: Wongi.Engine.WME,
        subject: %Wongi.Engine.DSL.Var{name: :planet},
        object: %Wongi.Engine.DSL.Var{name: :count_heavy_sats},
        predicate: :heavy_sats
      }

  Stacktrace:

    (elixir 1.19.1) lib/inspect/algebra.ex:749: Inspect.Algebra.concat({{:doc_group, [{:doc_nest, [[{:doc_color, "%Wongi.Engine.DSL.Var{", "\e[39m"} | {:doc_color, [], "\e[0m\e[33m"}], {:doc_break, "", :strict}, [{:doc_color, "name:", "\e[36m"} | {:doc_color, [], "\e[0m\e[33m"}], " ", {:doc_color, ":count_heavy_sats", "\e[36m"} | {:doc_color, [], "\e[0m\e[33m"}], 2, :always}, {:doc_break, "", :strict}, {:doc_color, "}", "\e[39m"} | {:doc_color, [], "\e[0m\e[33m"}], :normal}, %Inspect.Opts{base: :decimal, binaries: :infer, char_lists: :infer, charlists: :as_lists, custom_options: [], inspect_fun: &Inspect.inspect/2, limit: 69, pretty: true, printable_limit: 4096, safe: true, structs: true, syntax_colors: [reset: [:reset, :yellow], atom: :cyan, binary: :default_color, boolean: :magenta, charlist: :yellow, list: :default_color, map: :default_color, nil: :magenta, number: :yellow, string: :green, tuple: :default_color, variable: :light_cyan, call: :default_color, operator: :default_color], width: 80}}, ")")
    (elixir 1.19.1) lib/inspect/algebra.ex:1147: Inspect.Algebra.fold/2
    (elixir 1.19.1) lib/inspect/algebra.ex:401: Inspect.Algebra.to_doc_with_opts/2
    (elixir 1.19.1) lib/inspect.ex:415: Inspect.List.keyword/2
    (elixir 1.19.1) lib/inspect/algebra.ex:613: Inspect.Algebra.call_container_fun/3
    (elixir 1.19.1) lib/inspect/algebra.ex:590: Inspect.Algebra.container_each/5
    (elixir 1.19.1) lib/inspect/algebra.ex:566: Inspect.Algebra.container_doc_with_opts/6
    (elixir 1.19.1) lib/inspect/algebra.ex:401: Inspect.Algebra.to_doc_with_opts/2
    (elixir 1.19.1) lib/inspect/algebra.ex:613: Inspect.Algebra.call_container_fun/3
    (elixir 1.19.1) lib/inspect/algebra.ex:590: Inspect.Algebra.container_each/5
    (elixir 1.19.1) lib/inspect/algebra.ex:566: Inspect.Algebra.container_doc_with_opts/6
    (elixir 1.19.1) lib/inspect/algebra.ex:453: Inspect.Algebra.to_doc_with_opts/2
    (elixir 1.19.1) lib/inspect.ex:415: Inspect.List.keyword/2
    (elixir 1.19.1) lib/inspect/algebra.ex:613: Inspect.Algebra.call_container_fun/3
    (elixir 1.19.1) lib/inspect/algebra.ex:590: Inspect.Algebra.container_each/5
    (elixir 1.19.1) lib/inspect/algebra.ex:566: Inspect.Algebra.container_doc_with_opts/6
    (elixir 1.19.1) lib/inspect/algebra.ex:401: Inspect.Algebra.to_doc_with_opts/2
    (elixir 1.19.1) lib/inspect/algebra.ex:384: Inspect.Algebra.to_doc/2
    (elixir 1.19.1) lib/kernel.ex:2469: Kernel.inspect/2
    (iex 1.19.1) lib/iex/evaluator.ex:393: IEx.Evaluator.io_inspect/1
    (iex 1.19.1) lib/iex/evaluator.ex:352: IEx.Evaluator.eval_and_inspect/3
    (iex 1.19.1) lib/iex/evaluator.ex:321: IEx.Evaluator.safe_eval_and_inspect/3
    (iex 1.19.1) lib/iex/evaluator.ex:212: IEx.Evaluator.loop/1
    (iex 1.19.1) lib/iex/evaluator.ex:38: IEx.Evaluator.init/5
    (stdlib 7.1) proc_lib.erl:333: :proc_lib.init_p_do_apply/3

>,
      generator: nil
    }
  ]
}
```