### PR TITLE
handle Var as well as atom

### DIFF
--- a/lib/wongi/engine/dsl/aggregate.ex
+++ b/lib/wongi/engine/dsl/aggregate.ex
@@ -1,10 +1,11 @@
 defmodule Wongi.Engine.DSL.Aggregate do
   @moduledoc false
+  alias Wongi.Engine.DSL.Var
+
   defstruct [:fun, :var, opts: []]
 
-  def new(fun, var, opts) do
-    %__MODULE__{fun: fun, var: var, opts: opts}
-  end
+  def new(fun, %Var{name: name}, opts), do: %__MODULE__{fun: fun, var: name, opts: opts}
+  def new(fun, var, opts) when is_atom(var), do: %__MODULE__{fun: fun, var: var, opts: opts}
 
   defimpl Wongi.Engine.DSL.Clause do
     import Wongi.Engine.Compiler

--- a/lib/wongi/engine/dsl/assign.ex
+++ b/lib/wongi/engine/dsl/assign.ex
@@ -1,8 +1,11 @@
 defmodule Wongi.Engine.DSL.Assign do
   @moduledoc false
+  alias Wongi.Engine.DSL.Var
+
   defstruct [:name, :value]
 
-  def new(name, value), do: %__MODULE__{name: name, value: value}
+  def new(%Var{name: name}, value), do: %__MODULE__{name: name, value: value}
+  def new(name, value) when is_atom(name), do: %__MODULE__{name: name, value: value}
 
   defimpl Wongi.Engine.DSL.Clause do
     import Wongi.Engine.Compiler

--- a/lib/wongi/engine/token.ex
+++ b/lib/wongi/engine/token.ex
@@ -4,6 +4,7 @@ defmodule Wongi.Engine.Token do
   An intermediate data structure representing a partial match.
   """
   alias Wongi.Engine.Beta
+  alias Wongi.Engine.DSL.Var
   alias Wongi.Engine.WME
 
   @type t() :: %__MODULE__{}
@@ -31,8 +32,10 @@ defmodule Wongi.Engine.Token do
   end
 
   @doc "Returns the value of a bound variable."
-  @spec fetch(t(), atom()) :: {:ok, any()} | :error
-  def fetch(%__MODULE__{assignments: assignments, parents: parents}, var) do
+  @spec fetch(t(), atom() | Var.t()) :: {:ok, any()} | :error
+  def fetch(%__MODULE__{} = token, %Var{name: name}), do: fetch(token, name)
+
+  def fetch(%__MODULE__{assignments: assignments, parents: parents}, var) when is_atom(var) do
     case Map.fetch(assignments, var) do
       {:ok, _value} = ok ->
         ok
@@ -48,11 +51,16 @@ defmodule Wongi.Engine.Token do
   end
 
   @doc false
+  def fetch(%__MODULE__{} = token, %Var{name: name}, extra_assignments) do
+    fetch(token, name, extra_assignments)
+  end
+
   def fetch(
         %__MODULE__{} = token,
         var,
         extra_assignments
-      ) do
+      )
+      when is_atom(var) do
     case Map.fetch(extra_assignments, var) do
       {:ok, value} ->
         {:ok, value}


### PR DESCRIPTION
this PR allows `Vars` to be used as well as atoms in several places

* `Assign.new`
* `Aggregate.new`
* `Token.fetch`

these changes are to support the alt-DSL approach outlined in PR #37 , which binds `%Var{}` structs to the Elixir variables on the LHS of `<-` DSL expressions